### PR TITLE
Refactor CLI tests for readability

### DIFF
--- a/pyinit/setup_template.py
+++ b/pyinit/setup_template.py
@@ -5,7 +5,7 @@ with open("{readme}", "r") as fh:
    long_description = fh.read()
 
 setuptools.setup(
-   name="{package_name}", # Replace with your own username
+   name="{package_name}",
    version="{version}",
    author="{author}",
    author_email="{author_email}",

--- a/pyinit/setup_template.py
+++ b/pyinit/setup_template.py
@@ -1,23 +1,27 @@
+from textwrap import dedent
+
+
 def render(readme, package_name, version, author, author_email, description, url):
-    return f"""import setuptools
-
-with open("{readme}", "r") as fh:
-   long_description = fh.read()
-
-setuptools.setup(
-   name="{package_name}",
-   version="{version}",
-   author="{author}",
-   author_email="{author_email}",
-   description="{description}",
-   long_description=long_description,
-   long_description_content_type="text/markdown",
-   url="{url}",
-   packages=setuptools.find_packages(),
-   classifiers=[
-       "Programming Language :: Python :: 3",
-       "License :: OSI Approved :: MIT License",
-       "Operating System :: OS Independent",
-   ]
-)
-"""
+    return dedent(f"""
+    import setuptools
+    
+    with open("{readme}", "r") as fh:
+       long_description = fh.read()
+    
+    setuptools.setup(
+       name="{package_name}",
+       version="{version}",
+       author="{author}",
+       author_email="{author_email}",
+       description="{description}",
+       long_description=long_description,
+       long_description_content_type="text/markdown",
+       url="{url}",
+       packages=setuptools.find_packages(),
+       classifiers=[
+           "Programming Language :: Python :: 3",
+           "License :: OSI Approved :: MIT License",
+           "Operating System :: OS Independent",
+       ]
+    )
+    """.lstrip('\n'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
+from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -59,26 +60,27 @@ class TestCli(TestCase):
             self.assertTrue(test_root.joinpath('__init__.py').is_file())
 
             actual_setup_py = setup_py.read_text()
-            expected_setup_py = f"""import setuptools
-
-with open("{readme_file_name}", "r") as fh:
-   long_description = fh.read()
-
-setuptools.setup(
-   name="foobar",
-   version="0.0.0",
-   author="{author_name}",
-   author_email="{author_email}",
-   description="{description}",
-   long_description=long_description,
-   long_description_content_type="text/markdown",
-   url="{project_url}",
-   packages=setuptools.find_packages(),
-   classifiers=[
-       "Programming Language :: Python :: 3",
-       "License :: OSI Approved :: MIT License",
-       "Operating System :: OS Independent",
-   ]
-)
-"""
+            expected_setup_py = dedent(f"""
+            import setuptools
+            
+            with open("{readme_file_name}", "r") as fh:
+               long_description = fh.read()
+            
+            setuptools.setup(
+               name="foobar",
+               version="0.0.0",
+               author="{author_name}",
+               author_email="{author_email}",
+               description="{description}",
+               long_description=long_description,
+               long_description_content_type="text/markdown",
+               url="{project_url}",
+               packages=setuptools.find_packages(),
+               classifiers=[
+                   "Programming Language :: Python :: 3",
+                   "License :: OSI Approved :: MIT License",
+                   "Operating System :: OS Independent",
+               ]
+            )
+            """.lstrip('\n'))
             self.assertEqual(expected_setup_py, actual_setup_py)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,24 +8,31 @@ from pyinit import cli
 
 
 class TestCli(TestCase):
-
     @patch('pyinit.cli.input')
-    def test_main(self, mock_input):
+    def test_main_generates_project_with_markdown_readme(self, mock_input):
+        package_name = "foobar"
+        version = "0.0.0"
+        author_name = "test"
+        author_email = "test@example.com"
+        description = "This is a sample package"
+        project_url = "http://example.com"
+        readme_file_name = 'README.md'
+
         def input_side_effects(s):
             if s == "Enter Python package name: ":
-                return "Test"
+                return package_name
             elif s == "Enter Version number: ":
-                return "0.0.0"
+                return version
             elif s == "Enter author name: ":
-                return "test"
+                return author_name
             elif s == "Enter author email address: ":
-                return "test@example.com"
+                return author_email
             elif s == "Enter Description: ":
-                return "This is test"
+                return description
             elif s == "Enter Readme type ( markdown or rst ) : ":
                 return "markdown"
             elif s == "Enter Project URL: ":
-                return "http://example.com"
+                return project_url
 
         mock_input.side_effect = input_side_effects
 
@@ -33,28 +41,38 @@ class TestCli(TestCase):
 
             cli.main()
 
-            os.path.isdir(cwd + "/tests")
-            os.path.isdir(cwd + "/Test")
-            os.path.isfile(cwd + "/Test/__init__.py")
-            os.path.isfile(cwd + "/tests/__init__.py")
-            os.path.isfile(cwd + "/README.md")
+            pkg_root = Path(cwd)
 
-            with open(cwd + "/setup.py") as file:
-                setup_py = file.read()
-                expected_output = """import setuptools
+            module_root = pkg_root.joinpath(package_name)
+            test_root = pkg_root.joinpath('tests')
+            readme = pkg_root.joinpath(readme_file_name)
+            setup_py = pkg_root.joinpath('setup.py')
 
-with open("README.md", "r") as fh:
+            self.assertTrue(pkg_root.is_dir())
+
+            self.assertTrue(module_root.is_dir())
+            self.assertTrue(test_root.is_dir())
+
+            self.assertTrue(readme.is_file())
+
+            self.assertTrue(module_root.joinpath('__init__.py').is_file())
+            self.assertTrue(test_root.joinpath('__init__.py').is_file())
+
+            actual_setup_py = setup_py.read_text()
+            expected_setup_py = f"""import setuptools
+
+with open("{readme_file_name}", "r") as fh:
    long_description = fh.read()
 
 setuptools.setup(
-   name="Test", # Replace with your own username
+   name="foobar",
    version="0.0.0",
-   author="test",
-   author_email="test@example.com",
-   description="This is test",
+   author="{author_name}",
+   author_email="{author_email}",
+   description="{description}",
    long_description=long_description,
    long_description_content_type="text/markdown",
-   url="http://example.com",
+   url="{project_url}",
    packages=setuptools.find_packages(),
    classifiers=[
        "Programming Language :: Python :: 3",
@@ -63,5 +81,4 @@ setuptools.setup(
    ]
 )
 """
-                self.maxDiff = None
-                self.assertEqual(expected_output, setup_py)
+            self.assertEqual(expected_setup_py, actual_setup_py)

--- a/tests/test_setup_template.py
+++ b/tests/test_setup_template.py
@@ -1,4 +1,5 @@
 import unittest
+from textwrap import dedent
 
 from pyinit.setup_template import render
 
@@ -9,26 +10,27 @@ class TestSetupTemplate(unittest.TestCase):
         actual_output = render(readme="README.md", package_name="Test", version="0.0.0", author="test",
                                author_email="test@example.com",
                                description="This is test", url="http://example.com")
-        expected_output = """import setuptools
-
-with open("README.md", "r") as fh:
-   long_description = fh.read()
-
-setuptools.setup(
-   name="Test", # Replace with your own username
-   version="0.0.0",
-   author="test",
-   author_email="test@example.com",
-   description="This is test",
-   long_description=long_description,
-   long_description_content_type="text/markdown",
-   url="http://example.com",
-   packages=setuptools.find_packages(),
-   classifiers=[
-       "Programming Language :: Python :: 3",
-       "License :: OSI Approved :: MIT License",
-       "Operating System :: OS Independent",
-   ]
-)
-"""
+        expected_output = dedent("""
+        import setuptools
+        
+        with open("README.md", "r") as fh:
+           long_description = fh.read()
+        
+        setuptools.setup(
+           name="Test",
+           version="0.0.0",
+           author="test",
+           author_email="test@example.com",
+           description="This is test",
+           long_description=long_description,
+           long_description_content_type="text/markdown",
+           url="http://example.com",
+           packages=setuptools.find_packages(),
+           classifiers=[
+               "Programming Language :: Python :: 3",
+               "License :: OSI Approved :: MIT License",
+               "Operating System :: OS Independent",
+           ]
+        )
+        """.lstrip('\n'))
         self.assertEqual(expected_output, actual_output)


### PR DESCRIPTION
Consolidate tests to use pathlib.Path vs os.path
Fix a few missed assertions